### PR TITLE
ci: enable additional ruff rules from python-onvif-zeep-async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,28 +52,72 @@ docs = [
 [tool.ruff]
 line-length = 88
 lint.select = [
-  "B",   # flake8-bugbear
-  "D",   # flake8-docstrings
-  "C4",  # flake8-comprehensions
-  "S",   # flake8-bandit
-  "F",   # pyflake
-  "E",   # pycodestyle
-  "W",   # pycodestyle
-  "UP",  # pyupgrade
-  "I",   # isort
-  "RUF", # ruff specific
+  "A",     # flake8-builtins
+  "ASYNC", # flake8-async
+  "B",     # flake8-bugbear
+  "BLE",   # flake8-blind-except
+  "C4",    # flake8-comprehensions
+  "D",     # flake8-docstrings
+  "DTZ",   # flake8-datetimez
+  "E",     # pycodestyle
+  "EXE",   # flake8-executable
+  "F",     # pyflake
+  "FA",    # flake8-future-annotations
+  "FLY",   # flynt
+  "FURB",  # refurb
+  "G",     # flake8-logging-format
+  "I",     # isort
+  "ICN",   # flake8-import-conventions
+  "ISC",   # flake8-implicit-str-concat
+  "LOG",   # flake8-logging
+  "N",     # pep8-naming
+  "PERF",  # Perflint
+  "PGH",   # pygrep-hooks
+  "PIE",   # flake8-pie
+  "PL",    # pylint
+  "PT",    # flake8-pytest-style
+  "PTH",   # flake8-use-pathlib
+  "PYI",   # flake8-pyi
+  "Q",     # flake8-quotes
+  "RET",   # flake8-return
+  "RUF",   # ruff specific
+  "S",     # flake8-bandit
+  "SIM",   # flake8-simplify
+  "SLOT",  # flake8-slots
+  "T10",   # flake8-debugger
+  "T20",   # flake8-print
+  "TC",    # flake8-type-checking
+  "TID",   # flake8-tidy-imports
+  "TRY",   # tryceratops
+  "UP",    # pyupgrade
+  "W",     # pycodestyle
+  "YTT",   # flake8-2020
 ]
 lint.ignore = [
-  "D203", # 1 blank line required before class docstring
-  "D212", # Multi-line docstring summary should start at the first line
-  "D100", # Missing docstring in public module
-  "D104", # Missing docstring in public package
-  "D107", # Missing docstring in `__init__`
-  "D401", # First line of docstring should be in imperative mood
+  "D203",    # 1 blank line required before class docstring
+  "D212",    # Multi-line docstring summary should start at the first line
+  "D100",    # Missing docstring in public module
+  "D104",    # Missing docstring in public package
+  "D107",    # Missing docstring in `__init__`
+  "D401",    # First line of docstring should be in imperative mood
+  "PLR0911", # too many return statements
+  "PLR0912", # too many branches
+  "PLR0913", # too many arguments
+  "PLR0915", # too many statements
+  "PLR2004", # magic value used in comparison
+  "PLW2901", # loop variable overwritten
+  "TRY003",  # long messages outside exception class
 ]
 lint.per-file-ignores."conftest.py" = [ "D100" ]
-lint.per-file-ignores."docs/conf.py" = [ "D100" ]
-lint.per-file-ignores."setup.py" = [ "D100" ]
+lint.per-file-ignores."docs/conf.py" = [
+  "A001", # sphinx requires `copyright` variable name
+  "D100",
+]
+lint.per-file-ignores."setup.py" = [ "D100", "EXE001" ]
+lint.per-file-ignores."src/onvif_parsers/__main__.py" = [
+  "T201", # print is legitimate in CLI tool
+  "T203", # pprint is legitimate in CLI tool
+]
 lint.per-file-ignores."tests/**/*" = [
   "D100",
   "D101",
@@ -81,6 +125,8 @@ lint.per-file-ignores."tests/**/*" = [
   "D103",
   "D104",
   "S101",
+  "S105",
+  "S106",
 ]
 lint.isort.known-first-party = [ "onvif_parsers", "tests" ]
 

--- a/src/onvif_parsers/__main__.py
+++ b/src/onvif_parsers/__main__.py
@@ -3,11 +3,11 @@
 import argparse
 import asyncio
 import datetime
-import os.path
 import pprint
 import socket
 import sys
 import typing
+from pathlib import Path
 from types import TracebackType
 
 import onvif
@@ -44,7 +44,7 @@ class OnvifEventReceiver:
             args.port,
             args.username,
             args.password,
-            wsdl_dir=f"{os.path.dirname(onvif.__file__)}/wsdl/",
+            wsdl_dir=f"{Path(onvif.__file__).parent}/wsdl/",
         )
         self.manager: onvif.NotificationManager | None = None
         self.runner: web.AppRunner | None = None
@@ -245,7 +245,6 @@ def main() -> None:
         loop.run_until_complete(OnvifEventReceiver.run(args))
     except KeyboardInterrupt:
         print("Exiting due to keyboard interrupt")
-        pass
 
 
 if __name__ == "__main__":

--- a/src/onvif_parsers/parsers/tapo.py
+++ b/src/onvif_parsers/parsers/tapo.py
@@ -58,7 +58,7 @@ async def async_parse_tplink_detector(
             rule = source.Value
 
     for item in payload.Data.SimpleItem:
-        event_template = _TAPO_EVENT_TEMPLATES.get(item.Name, None)
+        event_template = _TAPO_EVENT_TEMPLATES.get(item.Name)
         if event_template is None:
             continue
 

--- a/src/onvif_parsers/util.py
+++ b/src/onvif_parsers/util.py
@@ -46,7 +46,7 @@ def event_to_debug_format(data: typing.Any) -> typing.Any:
         # It's an lxml Element. Convert the tree to a pretty XML string.
         try:
             return etree.tostring(data, pretty_print=True, encoding="unicode")
-        except Exception:
+        except Exception:  # noqa: BLE001 - debug helper must never raise
             return repr(data)
 
     return data

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -59,7 +59,9 @@ async def test_line_detector_crossed():
                         "_attr_1": None,
                     },
                     "Extension": None,
-                    "UtcTime": datetime.datetime(2020, 5, 24, 7, 24, 47),
+                    "UtcTime": datetime.datetime(
+                        2020, 5, 24, 7, 24, 47, tzinfo=datetime.timezone.utc
+                    ),
                     "PropertyOperation": "Initialized",
                     "_attr_1": {},
                 }

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -49,5 +49,5 @@ def test_double_registration():
     """Registering the same topic twice raises ValueError."""
     registry.register("test_topic2")(parser1)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="already registered"):
         registry.register("test_topic2")(parser1)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,5 @@
-import os
 import typing
+from pathlib import Path
 
 import onvif
 from lxml import etree
@@ -22,9 +22,9 @@ def _inflate_xml_strings(data: typing.Any) -> typing.Any:
     """
     if isinstance(data, dict):
         return {k: _inflate_xml_strings(v) for k, v in data.items()}
-    elif isinstance(data, list):
+    if isinstance(data, list):
         return [_inflate_xml_strings(i) for i in data]
-    elif isinstance(data, str):
+    if isinstance(data, str):
         clean_str = data.strip()
         if clean_str.startswith("<") and clean_str.endswith(">"):
             try:
@@ -45,7 +45,7 @@ def deserialize_event(notification_data: dict[typing.Any, typing.Any]) -> typing
     patched_data = _inflate_xml_strings(notification_data)
 
     zeep_client = Client(
-        f"{os.path.dirname(onvif.__file__)}/wsdl/events.wsdl",
+        f"{Path(onvif.__file__).parent}/wsdl/events.wsdl",
         wsse=None,
         transport=Transport(),
     )


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/openvideolibs/onvif-parsers/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include \`Fixes #0000\` (replacing \`0000\` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Brings the ruff lint set in line with python-onvif-zeep-async so the two repos share the same baseline; skipped a few opinionated rules (EM, ERA, FIX, INP, NPY, TD) and per-file-ignored T20 in the CLI entrypoint where print is legitimate. Cleaned up the handful of violations the new rules surfaced.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the \`main\` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/openvideolibs/onvif-parsers/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as \`Fixes #0000\`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try \`pre-commit run -a\` for further information.
> - If CI / test is failing, try \`uv run pytest\` for further information.

<!--
  🎉 Thank you for contributing!
-->